### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 before_script:
   - travis_retry composer self-update
@@ -11,4 +12,3 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "ottosmops/hash": "^1.0"
+        "php": ">=7.1"
     },
     "require-dev": {
         "phpunit/phpunit" : "~7.5",

--- a/tests/Md5sumTest.php
+++ b/tests/Md5sumTest.php
@@ -4,7 +4,6 @@ namespace Ottosmops\Hash\Test;
 use Ottosmops\Hash\Hash;
 
 use Ottosmops\Hash\Exceptions\FileNotFound;
-use Ottosmops\Hash\Exceptions\SeparatorNotFound;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
# Changed log
- Add `php-7.4` version test during Travis CI build.
- Removing its packages.
- Removing `SeparatorNotFound` class because this exception class is not used.